### PR TITLE
Swap command line arguments to follow FUSE standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Clone the project and build it.
 make build
 ```
 
-This generates an executable file ```etcdfs```. You can mount etcd as a filesystem by running ```etcdfs MOUNT_PATH ETCD_ENDPOINT```. For example:
+This generates an executable file ```etcdfs```. You can mount etcd as a filesystem by running ```etcdfs ETCD_ENDPOINT MOUNT_PATH```. For example:
 
 ```bash
 ./etcds /tmp/foobar http://localhost:4001

--- a/etcdfs.go
+++ b/etcdfs.go
@@ -11,11 +11,11 @@ import (
 func main() {
   flag.Parse()
   if len(flag.Args()) < 2 {
-    log.Fatal("Usage:\n  etcd-fs MOUNTPOINT ETCDENDPOINT")
+    log.Fatal("Usage:\n  etcd-fs ETCDENDPOINT MOUNTPOINT")
   }
-  etcdFs := EtcdFs{FileSystem: pathfs.NewDefaultFileSystem(), EtcdEndpoint: flag.Arg(1)}
+  etcdFs := EtcdFs{FileSystem: pathfs.NewDefaultFileSystem(), EtcdEndpoint: flag.Arg(0)}
   nfs := pathfs.NewPathNodeFs(&etcdFs, nil)
-  server, _, err := nodefs.MountRoot(flag.Arg(0), nfs.Root(), nil)
+  server, _, err := nodefs.MountRoot(flag.Arg(1), nfs.Root(), nil)
   if err != nil {
     log.Fatalf("Mount fail: %v\n", err)
   }


### PR DESCRIPTION
As mentioned in #12 
The order of the command line interface arguments should be swapped to follow the FUSE standard way.